### PR TITLE
Add support for hex colour codes (#27)

### DIFF
--- a/bukkit/src/main/java/com/lauriethefish/betterportals/bukkit/config/MessageConfig.java
+++ b/bukkit/src/main/java/com/lauriethefish/betterportals/bukkit/config/MessageConfig.java
@@ -23,6 +23,21 @@ import java.util.Objects;
  */
 @Singleton
 public class MessageConfig {
+    private static final boolean HEX_COLOR_CODES_AVAILABLE;
+
+    static {
+        boolean isAvailable = false;
+
+        if(VersionUtil.isMcVersionAtLeast("1.16.0")) {
+            try {
+                Class.forName("net.md_5.bungee.api.ChatColor");
+                isAvailable = true;
+            }   catch(ClassNotFoundException ignored) {}
+        }
+
+        HEX_COLOR_CODES_AVAILABLE = isAvailable;
+    }
+
     private static final String PORTAL_WAND_TAG = "portalWand";
 
     private final Map<String, String> messageMap = new HashMap<>();
@@ -48,10 +63,14 @@ public class MessageConfig {
     private String translateColorCodes(String message) {
         message = ChatColor.translateAlternateColorCodes('&', message);
 
-        if(!VersionUtil.isMcVersionAtLeast("1.16.0") || !Bukkit.getBukkitVersion().contains("craftbukkit")) {
+        if (HEX_COLOR_CODES_AVAILABLE) {
+            return translateHexColors(message);
+        }   else    {
             return message;
         }
+    }
 
+    private String translateHexColors(String message) {
         boolean previousWasOpenBrace = false;
         boolean recordingHex = false;
         StringBuilder currentHex = null;

--- a/bukkit/src/main/java/com/lauriethefish/betterportals/bukkit/config/MessageConfig.java
+++ b/bukkit/src/main/java/com/lauriethefish/betterportals/bukkit/config/MessageConfig.java
@@ -67,7 +67,12 @@ public class MessageConfig {
         messageColor = translateColorCodes(Objects.requireNonNull(messagesSection.getString("messageColor"), "Missing messageColor"));
     }
 
-    private String translateColorCodes(String message) {
+    /**
+     * Translates both the <code>&</code> color codes, and hex colours if on 1.16 spigot.
+     * @param message The message to translate
+     * @return The translated message with the colours
+     */
+    private @NotNull String translateColorCodes(@NotNull String message) {
         message = ChatColor.translateAlternateColorCodes('&', message);
 
         if (HEX_COLOR_CODES_AVAILABLE) {
@@ -77,7 +82,13 @@ public class MessageConfig {
         }
     }
 
-    private String translateHexColors(String message) {
+    /**
+     * Translates hex colour codes in <code>message</code>, e.g. <code>{(#000000)}</code> is black.
+     * Invalid colour codes print a warning and are removed.
+     * @param message The message to translate
+     * @return The translated message with the colours
+     */
+    private @NotNull String translateHexColors(@NotNull String message) {
         boolean previousWasOpenBrace = false;
         boolean recordingHex = false;
         StringBuilder currentHex = null;

--- a/bukkit/src/main/java/com/lauriethefish/betterportals/bukkit/config/MessageConfig.java
+++ b/bukkit/src/main/java/com/lauriethefish/betterportals/bukkit/config/MessageConfig.java
@@ -1,11 +1,12 @@
 package com.lauriethefish.betterportals.bukkit.config;
 
+import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.lauriethefish.betterportals.bukkit.command.framework.CommandException;
 import com.lauriethefish.betterportals.bukkit.util.VersionUtil;
 import com.lauriethefish.betterportals.bukkit.util.nms.NBTTagUtil;
+import com.lauriethefish.betterportals.shared.logging.Logger;
 import lombok.Getter;
-import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
@@ -40,6 +41,7 @@ public class MessageConfig {
 
     private static final String PORTAL_WAND_TAG = "portalWand";
 
+    private final Logger logger;
     private final Map<String, String> messageMap = new HashMap<>();
 
     private String portalWandName;
@@ -47,6 +49,11 @@ public class MessageConfig {
     @Getter private String messageColor;
 
     private ItemStack portalWand = null;
+
+    @Inject
+    public MessageConfig(Logger logger) {
+        this.logger = logger;
+    }
 
     public void load(FileConfiguration file) {
         ConfigurationSection messagesSection = Objects.requireNonNull(file.getConfigurationSection("chatMessages"), "Missing chat messages section");
@@ -79,7 +86,11 @@ public class MessageConfig {
             if(recordingHex) {
                 if(c == ')') {
                     recordingHex = false;
-                    translatedMessage.append(net.md_5.bungee.api.ChatColor.of(currentHex.toString()));
+                    try {
+                        translatedMessage.append(net.md_5.bungee.api.ChatColor.of(currentHex.toString()));
+                    }   catch(IllegalArgumentException ex) {
+                        logger.warning("Failed to parse hex colour: %s", currentHex.toString());
+                    }
                     continue;
                 }
 


### PR DESCRIPTION
Changes:
- Hex colours are now supported in chat messages, and in the prefix.
They can be used like this: `My message {(#000000)} is now black!` for example.
Hex colours are automatically disabled if not on spigot (craftbukkit doesn't have the API), or if on a version earlier than 1.16.