### PR TITLE
Add Velocity support

### DIFF
--- a/bukkit/src/main/resources/config.yml
+++ b/bukkit/src/main/resources/config.yml
@@ -59,7 +59,7 @@ maxPortalSize:
 portalCollisionBox:
   x: 0.50
   y: 0.50
-  z: 0.25
+  z: 0.50
 
 # Worlds where the plugin will fall back to the vanilla portal logic
 disabledWorlds:

--- a/bungee/build.gradle
+++ b/bungee/build.gradle
@@ -11,6 +11,7 @@ repositories {
 dependencies {
     implementation 'org.bstats:bstats-bungeecord:2.2.1'
     implementation project(':shared')
+    implementation project(':proxy')
     compileOnly 'net.md-5:bungeecord-api:1.18-R0.1-SNAPSHOT'
 }
 

--- a/bungee/src/main/java/com/lauriethefish/betterportals/bungee/BetterPortals.java
+++ b/bungee/src/main/java/com/lauriethefish/betterportals/bungee/BetterPortals.java
@@ -3,8 +3,8 @@ package com.lauriethefish.betterportals.bungee;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
-import com.lauriethefish.betterportals.bungee.net.IPortalServer;
-import com.lauriethefish.betterportals.bungee.net.PortalServer;
+import com.lauriethefish.betterportals.proxy.net.IPortalServer;
+import com.lauriethefish.betterportals.proxy.net.PortalServer;
 import com.lauriethefish.betterportals.shared.logging.Logger;
 import com.lauriethefish.betterportals.shared.net.DisconnectNotice;
 import net.md_5.bungee.api.plugin.Plugin;
@@ -18,7 +18,6 @@ public class BetterPortals extends Plugin {
     @Override
     public void onEnable() {
         Injector injector = Guice.createInjector(new MainModule(this));
-        DisconnectNotice disconnectNotice = new DisconnectNotice(); // Purely to aid class loading during development, please don't remove this
 
         try {
             config.load();

--- a/bungee/src/main/java/com/lauriethefish/betterportals/bungee/BungeeProxy.java
+++ b/bungee/src/main/java/com/lauriethefish/betterportals/bungee/BungeeProxy.java
@@ -1,0 +1,68 @@
+package com.lauriethefish.betterportals.bungee;
+
+import com.lauriethefish.betterportals.proxy.IProxy;
+import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.config.ServerInfo;
+import net.md_5.bungee.api.connection.ProxiedPlayer;
+import net.md_5.bungee.api.plugin.Plugin;
+import org.jetbrains.annotations.Nullable;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.net.InetSocketAddress;
+import java.util.UUID;
+
+@Singleton
+public class BungeeProxy implements IProxy {
+    private final Plugin pl;
+    private final ProxyServer proxyServer;
+
+    @Inject
+    public BungeeProxy(Plugin pl) {
+        this.pl = pl;
+        this.proxyServer = pl.getProxy();
+    }
+
+    @Override
+    public String getPluginVersion() {
+        return pl.getDescription().getVersion();
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public @Nullable String findServer(InetSocketAddress clientAddress) {
+        for(ServerInfo server : proxyServer.getServers().values()) {
+            InetSocketAddress serverAddress = server.getAddress();
+            if(serverAddress.equals(clientAddress)) {
+                return server.getName();
+            }
+        }
+
+        return null;
+    }
+
+    @Override
+    public boolean serverExists(String serverName) {
+        return proxyServer.getServerInfo(serverName) != null;
+    }
+
+    @Override
+    public boolean playerExists(UUID uid) {
+        return proxyServer.getPlayer(uid) != null;
+    }
+
+    @Override
+    public void changePlayerServer(UUID uid, String destinationServer) {
+        ProxiedPlayer playerInfo = proxyServer.getPlayer(uid);
+        if(playerInfo == null) {
+            throw new IllegalArgumentException(String.format("No player existed with UUID %s", uid));
+        }
+
+        ServerInfo serverInfo = proxyServer.getServerInfo(destinationServer);
+        if(serverInfo == null) {
+            throw new IllegalArgumentException(String.format("No server existed with the UUID %s", destinationServer));
+        }
+
+        playerInfo.connect(serverInfo);
+    }
+}

--- a/bungee/src/main/java/com/lauriethefish/betterportals/bungee/Config.java
+++ b/bungee/src/main/java/com/lauriethefish/betterportals/bungee/Config.java
@@ -2,6 +2,7 @@ package com.lauriethefish.betterportals.bungee;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import com.lauriethefish.betterportals.proxy.IProxyConfig;
 import com.lauriethefish.betterportals.shared.logging.Logger;
 import lombok.Getter;
 import net.md_5.bungee.api.plugin.Plugin;
@@ -23,7 +24,7 @@ import java.util.logging.Level;
  * This class handles loading and saving of the config file.
  */
 @Singleton
-public class Config {
+public class Config implements IProxyConfig {
     private final Plugin pl;
     private final Logger logger;
 

--- a/bungee/src/main/java/com/lauriethefish/betterportals/bungee/MainModule.java
+++ b/bungee/src/main/java/com/lauriethefish/betterportals/bungee/MainModule.java
@@ -1,14 +1,12 @@
 package com.lauriethefish.betterportals.bungee;
 
 import com.google.inject.AbstractModule;
-import com.google.inject.assistedinject.FactoryModuleBuilder;
-import com.lauriethefish.betterportals.bungee.net.*;
+import com.lauriethefish.betterportals.proxy.IProxyConfig;
+import com.lauriethefish.betterportals.proxy.IProxy;
+import com.lauriethefish.betterportals.proxy.net.*;
 import com.lauriethefish.betterportals.shared.logging.Logger;
 import com.lauriethefish.betterportals.shared.logging.OverrideLogger;
-import com.lauriethefish.betterportals.shared.net.IRequestHandler;
-import com.lauriethefish.betterportals.shared.net.encryption.EncryptedObjectStream;
-import com.lauriethefish.betterportals.shared.net.encryption.EncryptedObjectStreamFactory;
-import com.lauriethefish.betterportals.shared.net.encryption.IEncryptedObjectStream;
+
 import net.md_5.bungee.api.plugin.Plugin;
 
 public class MainModule extends AbstractModule {
@@ -20,11 +18,11 @@ public class MainModule extends AbstractModule {
     @Override
     public void configure() {
         bind(Plugin.class).toInstance(pl);
+        bind(IProxyConfig.class).to(Config.class);
+        bind(IProxy.class).to(BungeeProxy.class);
+
+        install(new ProxyModule());
 
         bind(Logger.class).toInstance(new OverrideLogger(pl.getLogger()));
-        bind(IPortalServer.class).to(PortalServer.class);
-        bind(IRequestHandler.class).to(ProxyRequestHandler.class);
-        install(new FactoryModuleBuilder().implement(IClientHandler.class, ClientHandler.class).build(ServerHandlerFactory.class));
-        install(new FactoryModuleBuilder().implement(IEncryptedObjectStream.class, EncryptedObjectStream.class).build(EncryptedObjectStreamFactory.class));
     }
 }

--- a/bungee/src/main/java/com/lauriethefish/betterportals/bungee/ServerSwitch.java
+++ b/bungee/src/main/java/com/lauriethefish/betterportals/bungee/ServerSwitch.java
@@ -1,8 +1,8 @@
 package com.lauriethefish.betterportals.bungee;
 
 import com.google.inject.Inject;
-import com.lauriethefish.betterportals.bungee.net.IClientHandler;
-import com.lauriethefish.betterportals.bungee.net.IPortalServer;
+import com.lauriethefish.betterportals.proxy.net.IClientHandler;
+import com.lauriethefish.betterportals.proxy.net.IPortalServer;
 import com.lauriethefish.betterportals.shared.logging.Logger;
 import com.lauriethefish.betterportals.shared.net.RequestException;
 import com.lauriethefish.betterportals.shared.net.requests.PreviousServerPutRequest;

--- a/bungee/src/main/java/com/lauriethefish/betterportals/bungee/net/ServerHandlerFactory.java
+++ b/bungee/src/main/java/com/lauriethefish/betterportals/bungee/net/ServerHandlerFactory.java
@@ -1,7 +1,0 @@
-package com.lauriethefish.betterportals.bungee.net;
-
-import java.net.Socket;
-
-public interface ServerHandlerFactory {
-    IClientHandler create(Socket socket);
-}

--- a/final/build.gradle
+++ b/final/build.gradle
@@ -7,9 +7,10 @@ dependencies {
     implementation project(':bukkit')
     implementation project(':bungee')
     implementation project(':api')
+    implementation project(':velocity')
 }
 
-def getImplementationConfigurations(parentProject) {
+def static getImplementationConfigurations(parentProject) {
     parentProject.configurations.implementation.canBeResolved = true
     return parentProject.configurations.implementation
 }
@@ -21,8 +22,6 @@ shadowJar {
     configurations = [getImplementationConfigurations(project), getImplementationConfigurations(project(':bukkit'))]
 
     relocate 'org.bstats', 'com.lauriethefish.betterportals.dependencies.org.bstats'
-    relocate 'javax.annotation', 'com.lauriethefish.betterportals.dependencies.javax.annotation'
-    relocate 'javax.inject', 'com.lauriethefish.betterportals.dependencies.javax.inject'
     relocate 'org.aopalliance', 'com.lauriethefish.betterportals.dependencies.aopalliance'
     relocate 'org.checkerframework', 'com.lauriethefish.betterportals.dependencies.checkerframework'
     relocate 'org.intellij.lang.annotations', 'com.lauriethefish.betterportals.dependencies.intellij.lang.annotations'

--- a/final/src/main/java/com/lauriethefish/betterportals/MinimisationEntryPoint.java
+++ b/final/src/main/java/com/lauriethefish/betterportals/MinimisationEntryPoint.java
@@ -6,4 +6,5 @@ package com.lauriethefish.betterportals;
 public class MinimisationEntryPoint {
     private static final Class<?> BUKKIT = com.lauriethefish.betterportals.bukkit.BetterPortals.class;
     private static final Class<?> BUNGEE = com.lauriethefish.betterportals.bungee.BetterPortals.class;
+    private static final Class<?> VELOCITY = com.lauriethefish.betterportals.velocity.BetterPortals.class;
 }

--- a/proxy/build.gradle
+++ b/proxy/build.gradle
@@ -1,0 +1,4 @@
+
+dependencies {
+    implementation(project(":shared"))
+}

--- a/proxy/src/main/java/com/lauriethefish/betterportals/proxy/IProxy.java
+++ b/proxy/src/main/java/com/lauriethefish/betterportals/proxy/IProxy.java
@@ -1,0 +1,44 @@
+package com.lauriethefish.betterportals.proxy;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.net.InetSocketAddress;
+import java.util.UUID;
+
+public interface IProxy {
+    /**
+     * Gets the version of BetterPortals on the proxy
+     * @return The version of BetterPortals currently running
+     */
+    String getPluginVersion();
+
+    /**
+     * Finds the server with the address <code>clientAddress</code>.
+     * @param clientAddress The address to search for
+     * @return The name of server with this address, or null if there is none
+     */
+    @Deprecated
+    @Nullable String findServer(InetSocketAddress clientAddress);
+
+    /**
+     * Finds if the server with the given name exists
+     * @param serverName Name of the server to check
+     * @return True if a server exists with that name, false otherwise
+     */
+    boolean serverExists(String serverName);
+
+    /**
+     * Finds if a player exists with the given unique ID
+     * @param uid The unique ID
+     * @return True if a player exists with this unique ID, false otherwise
+     */
+    boolean playerExists(UUID uid);
+
+    /**
+     * Teleports a player to the server with the given name
+     * @param uid The unique ID of the player
+     * @param destinationServer The server that the player will be teleported to
+     * @throws IllegalArgumentException If no player exists with the given unique ID, or no server exists with the given name
+     */
+    void changePlayerServer(UUID uid, String destinationServer);
+}

--- a/proxy/src/main/java/com/lauriethefish/betterportals/proxy/IProxyConfig.java
+++ b/proxy/src/main/java/com/lauriethefish/betterportals/proxy/IProxyConfig.java
@@ -1,0 +1,18 @@
+package com.lauriethefish.betterportals.proxy;
+
+import java.net.InetSocketAddress;
+import java.util.UUID;
+
+public interface IProxyConfig {
+    /**
+     * Gets the bind address
+     * @return The address for the BP server to bind to
+     */
+    InetSocketAddress getBindAddress();
+
+    /**
+     * Gets the encryption key
+     * @return The key used for encrypted communication with the bukkit servers
+     */
+    UUID getKey();
+}

--- a/proxy/src/main/java/com/lauriethefish/betterportals/proxy/net/ClientHandler.java
+++ b/proxy/src/main/java/com/lauriethefish/betterportals/proxy/net/ClientHandler.java
@@ -57,12 +57,14 @@ public class ClientHandler implements IClientHandler {
                     return;
                 } // An IOException gets thrown if another thread shuts down this connection
 
-                logger.warning("An IO error occurred while connected to %s", socket.getRemoteSocketAddress());
-                ex.printStackTrace();
+                if(ex.getCause() instanceof AEADBadTagException) {
+                    printEncryptionFailure();
+                }   else    {
+                    logger.warning("An IO error occurred while connected to %s", socket.getRemoteSocketAddress());
+                    ex.printStackTrace();
+                }
             }   catch(AEADBadTagException ex) {
-                logger.warning("Failed to initialise encryption with %s", socket.getRemoteSocketAddress());
-                logger.warning("Please make sure that your encryption key is valid!");
-                ex.printStackTrace();
+                printEncryptionFailure();
             }   catch(Exception ex) {
                 logger.warning("An error occurred while connected to %s", socket.getRemoteSocketAddress());
                 ex.printStackTrace();
@@ -70,6 +72,11 @@ public class ClientHandler implements IClientHandler {
                 disconnect();
             }
         }).start();
+    }
+
+    private void printEncryptionFailure() {
+        logger.warning("Failed to initialise encryption with %s", socket.getRemoteSocketAddress());
+        logger.warning("Please make sure that your encryption key is valid!");
     }
 
     /**

--- a/proxy/src/main/java/com/lauriethefish/betterportals/proxy/net/ClientHandler.java
+++ b/proxy/src/main/java/com/lauriethefish/betterportals/proxy/net/ClientHandler.java
@@ -1,17 +1,15 @@
-package com.lauriethefish.betterportals.bungee.net;
+package com.lauriethefish.betterportals.proxy.net;
 
 import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
+import com.lauriethefish.betterportals.proxy.IProxy;
 import com.lauriethefish.betterportals.shared.logging.Logger;
 import com.lauriethefish.betterportals.shared.net.*;
 import com.lauriethefish.betterportals.shared.net.encryption.EncryptedObjectStreamFactory;
 import com.lauriethefish.betterportals.shared.net.encryption.IEncryptedObjectStream;
 import com.lauriethefish.betterportals.shared.net.requests.Request;
 import lombok.Getter;
-import net.md_5.bungee.api.config.ServerInfo;
-import net.md_5.bungee.api.plugin.Plugin;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import javax.crypto.AEADBadTagException;
 import java.io.IOException;
@@ -26,15 +24,16 @@ import java.util.function.Consumer;
 public class ClientHandler implements IClientHandler {
     private final IPortalServer portalServer;
     private final Logger logger;
-    private final Plugin pl;
     private final EncryptedObjectStreamFactory encryptedObjectStreamFactory;
     private final IRequestHandler requestHandler;
 
     private final Socket socket;
     private IEncryptedObjectStream objectStream;
 
-    @Getter private ServerInfo serverInfo = null;
+    @Getter private String serverName = null;
     @Getter private String gameVersion;
+
+    private final IProxy proxy;
 
     private volatile boolean isRunning = true;
 
@@ -42,13 +41,13 @@ public class ClientHandler implements IClientHandler {
     private final ConcurrentMap<Integer, Consumer<Response>> waitingRequests = new ConcurrentHashMap<>();
 
     @Inject
-    public ClientHandler(@Assisted Socket socket, IPortalServer portalServer, Logger logger, Plugin pl, EncryptedObjectStreamFactory encryptedObjectStreamFactory, IRequestHandler requestHandler) {
+    public ClientHandler(@Assisted Socket socket, IPortalServer portalServer, Logger logger, EncryptedObjectStreamFactory encryptedObjectStreamFactory, IRequestHandler requestHandler, IProxy proxy) {
         this.socket = socket;
         this.portalServer = portalServer;
         this.logger = logger;
-        this.pl = pl;
         this.encryptedObjectStreamFactory = encryptedObjectStreamFactory;
         this.requestHandler = requestHandler;
+        this.proxy = proxy;
 
         new Thread(() -> {
             try {
@@ -84,7 +83,7 @@ public class ClientHandler implements IClientHandler {
 
         // The plugin version needs to be the same, since the protocol may have changed
         HandshakeResponse.Result result = HandshakeResponse.Result.SUCCESS;
-        if(!pl.getDescription().getVersion().equals(handshake.getPluginVersion())) {
+        if(!proxy.getPluginVersion().equals(handshake.getPluginVersion())) {
             logger.warning("A server tried to register with a different plugin version (%s)", handshake.getPluginVersion());
             result = HandshakeResponse.Result.PLUGIN_VERSION_MISMATCH;
         }
@@ -92,24 +91,23 @@ public class ClientHandler implements IClientHandler {
         InetSocketAddress statedServerAddress = new InetSocketAddress(socket.getInetAddress(), handshake.getServerPort());
 
         // Find the bungeecord server that the connector is connecting from
-        ServerInfo serverInfo = null;
-        String statedServerName = handshake.getOverrideServerName();
-        if(statedServerName != null) {
-            logger.finer("Using manually stated server name %s", statedServerName);
-            serverInfo = pl.getProxy().getServerInfo(statedServerName);
+        String serverName = handshake.getOverrideServerName();
+        if(serverName != null) {
+            logger.finer("Using manually stated server name %s", serverName);
 
-            if(serverInfo == null) {
-                logger.warning("Server name %s was stated by a client, but no listed server existed with that name!", statedServerName);
+            if(!proxy.serverExists(serverName)) {
+                logger.warning("Server name %s was stated by a client, but no listed server existed with that name!", serverName);
+                serverName = null;
             }
         }
 
-        if(serverInfo == null) {
-            logger.fine("Finding server info from socket address and port");
-            serverInfo = findServer(statedServerAddress);
+        if(serverName == null) {
+            logger.warning("Finding server info from socket address and port, this behaviour is deprecated!");
+            serverName = proxy.findServer(statedServerAddress);
         }
 
-        if(serverInfo == null) {
-            logger.warning("A server tried to register that didn't exist in bungeecord");
+        if(serverName == null) {
+            logger.warning("A server tried to register that didn't exist on the proxy!");
             result = HandshakeResponse.Result.SERVER_NOT_REGISTERED;
         }
 
@@ -118,32 +116,15 @@ public class ClientHandler implements IClientHandler {
         send(response);
 
         if(result == HandshakeResponse.Result.SUCCESS) {
-            logger.fine("Successfully registered with server %s", serverInfo.getName());
+            logger.fine("Successfully registered with server %s", serverName);
             logger.fine("Plugin version: %s. Game version: %s.", handshake.getPluginVersion(), handshake.getGameVersion());
-            portalServer.registerServer(this, serverInfo);
-            this.serverInfo = serverInfo;
+            portalServer.registerServer(this, serverName);
+            this.serverName = serverName;
             this.gameVersion = handshake.getGameVersion();
             return true;
         }   else    {
             return false;
         }
-    }
-
-    /**
-     * Finds the bungeecord server with the address <code>clientAddress</code>.
-     * @param clientAddress The address to search for
-     * @return The server with this address, or null if there is none
-     */
-    @SuppressWarnings("deprecation")
-    private @Nullable ServerInfo findServer(InetSocketAddress clientAddress) {
-        for(ServerInfo server : pl.getProxy().getServers().values()) {
-            InetSocketAddress serverAddress = server.getAddress();
-            if(serverAddress.equals(clientAddress)) {
-                return server;
-            }
-        }
-
-        return null;
     }
 
     private void run() throws IOException, ClassNotFoundException, GeneralSecurityException    {
@@ -239,7 +220,7 @@ public class ClientHandler implements IClientHandler {
     }
 
     private void verifyCanSendRequests() {
-        if(serverInfo == null) {
+        if(serverName == null) {
             throw new IllegalStateException("Attempted to send request before handshake was finished");
         }
     }

--- a/proxy/src/main/java/com/lauriethefish/betterportals/proxy/net/IClientHandler.java
+++ b/proxy/src/main/java/com/lauriethefish/betterportals/proxy/net/IClientHandler.java
@@ -1,11 +1,11 @@
-package com.lauriethefish.betterportals.bungee.net;
+package com.lauriethefish.betterportals.proxy.net;
 
 import com.lauriethefish.betterportals.shared.net.Response;
 import com.lauriethefish.betterportals.shared.net.requests.Request;
-import net.md_5.bungee.api.config.ServerInfo;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.net.Socket;
 import java.util.function.Consumer;
 
 /**
@@ -18,9 +18,9 @@ public interface IClientHandler {
     @Nullable String getGameVersion();
 
     /**
-     * @return The bungeecord {@link ServerInfo} that this server handler represents, or null if the server hasn't completed the handshake
+     * @return The name of the server that this client is connected to
      */
-    @Nullable ServerInfo getServerInfo();
+    @Nullable String getServerName();
 
     /**
      * Safely shuts down the connection to the server by sending a disconnection notice. Called on portal server shutdown.
@@ -34,4 +34,8 @@ public interface IClientHandler {
      * @param onFinish Called with the response when it is received.
      */
     void sendRequest(@NotNull Request request, @NotNull Consumer<Response> onFinish);
+
+    interface Factory {
+        IClientHandler create(Socket socket);
+    }
 }

--- a/proxy/src/main/java/com/lauriethefish/betterportals/proxy/net/IPortalServer.java
+++ b/proxy/src/main/java/com/lauriethefish/betterportals/proxy/net/IPortalServer.java
@@ -1,6 +1,5 @@
-package com.lauriethefish.betterportals.bungee.net;
+package com.lauriethefish.betterportals.proxy.net;
 
-import net.md_5.bungee.api.config.ServerInfo;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -26,9 +25,9 @@ public interface IPortalServer {
     /**
      * Registers the given server when the handshake has succeeded.
      * @param serverHandler The server to register
-     * @param serverInfo The {@link ServerInfo} that this server's address and port correspond to.
+     * @param serverName The name of the server to register
      */
-    void registerServer(@NotNull IClientHandler serverHandler, @NotNull ServerInfo serverInfo);
+    void registerServer(@NotNull IClientHandler serverHandler, @NotNull String serverName);
 
     /**
      * Unregisters the given client if it is registered.

--- a/proxy/src/main/java/com/lauriethefish/betterportals/proxy/net/PortalServer.java
+++ b/proxy/src/main/java/com/lauriethefish/betterportals/proxy/net/PortalServer.java
@@ -1,11 +1,10 @@
-package com.lauriethefish.betterportals.bungee.net;
+package com.lauriethefish.betterportals.proxy.net;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import com.lauriethefish.betterportals.bungee.Config;
+import com.lauriethefish.betterportals.proxy.IProxyConfig;
 import com.lauriethefish.betterportals.shared.logging.Logger;
 import com.lauriethefish.betterportals.shared.net.encryption.CipherManager;
-import net.md_5.bungee.api.config.ServerInfo;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -20,8 +19,8 @@ import java.util.concurrent.ConcurrentHashMap;
 @Singleton
 public class PortalServer implements IPortalServer {
     private final Logger logger;
-    private final Config config;
-    private final ServerHandlerFactory serverHandlerFactory;
+    private final IProxyConfig config;
+    private final IClientHandler.Factory serverHandlerFactory;
 
     private final Set<IClientHandler> connectedServers = new HashSet<>();
     private final Map<String, IClientHandler> registeredServers = new ConcurrentHashMap<>();
@@ -30,7 +29,7 @@ public class PortalServer implements IPortalServer {
     private volatile boolean isRunning = false;
 
     @Inject
-    public PortalServer(Logger logger, CipherManager cipherManager, Config config, ServerHandlerFactory serverHandlerFactory) throws Exception    {
+    public PortalServer(Logger logger, CipherManager cipherManager, IProxyConfig config, IClientHandler.Factory serverHandlerFactory) throws Exception    {
         this.logger = logger;
         this.config = config;
         this.serverHandlerFactory = serverHandlerFactory;
@@ -98,21 +97,21 @@ public class PortalServer implements IPortalServer {
     }
 
     @Override
-    public void registerServer(@NotNull IClientHandler serverHandler, @NotNull ServerInfo serverInfo) {
+    public void registerServer(@NotNull IClientHandler serverHandler, @NotNull String serverName) {
         if(!connectedServers.contains(serverHandler)) {
             throw new IllegalArgumentException("Attempted to register server that wasn't connected");
         }
 
-        registeredServers.put(serverInfo.getName(), serverHandler);
+        registeredServers.put(serverName, serverHandler);
     }
 
     @Override
     public void onServerDisconnect(@NotNull IClientHandler handler) {
         connectedServers.remove(handler);
-        ServerInfo serverInfo = handler.getServerInfo();
-        if(serverInfo != null) {
-            logger.finer("Server %s disconnected from the portal server", serverInfo.getName());
-            registeredServers.remove(serverInfo.getName());
+        String serverName = handler.getServerName();
+        if(serverName != null) {
+            logger.finer("Server %s disconnected from the portal server", serverName);
+            registeredServers.remove(serverName);
         }   else    {
             logger.finer("Unregistered server disconnected from the portal server");
         }

--- a/proxy/src/main/java/com/lauriethefish/betterportals/proxy/net/ProxyModule.java
+++ b/proxy/src/main/java/com/lauriethefish/betterportals/proxy/net/ProxyModule.java
@@ -1,0 +1,30 @@
+package com.lauriethefish.betterportals.proxy.net;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.assistedinject.FactoryModuleBuilder;
+import com.lauriethefish.betterportals.proxy.IProxyConfig;
+import com.lauriethefish.betterportals.proxy.IProxy;
+import com.lauriethefish.betterportals.shared.net.IRequestHandler;
+import com.lauriethefish.betterportals.shared.net.encryption.EncryptedObjectStream;
+import com.lauriethefish.betterportals.shared.net.encryption.EncryptedObjectStreamFactory;
+import com.lauriethefish.betterportals.shared.net.encryption.IEncryptedObjectStream;
+
+/**
+ * Configures the BetterPortals proxy server for viewing cross server portals
+ * User will also need to bind an implementation of {@link IProxy} and {@link IProxyConfig}
+ */
+public class ProxyModule extends AbstractModule {
+    protected void configure() {
+        bind(IPortalServer.class).to(PortalServer.class);
+        bind(IRequestHandler.class).to(ProxyRequestHandler.class);
+
+        install(new FactoryModuleBuilder()
+                .implement(IClientHandler.class, ClientHandler.class)
+                .build(IClientHandler.Factory.class)
+        );
+        install(new FactoryModuleBuilder()
+                .implement(IEncryptedObjectStream.class, EncryptedObjectStream.class)
+                .build(EncryptedObjectStreamFactory.class)
+        );
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,4 +10,4 @@ pluginManagement {
 rootProject.name = 'BetterPortals'
 gradle.ext.versionName = '0.10.0'
 
-include 'bukkit', 'bungee', 'shared', 'api', 'final'
+include 'bukkit', 'bungee', 'shared', 'api', 'final', 'velocity'

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,4 +10,4 @@ pluginManagement {
 rootProject.name = 'BetterPortals'
 gradle.ext.versionName = '0.10.0'
 
-include 'bukkit', 'bungee', 'shared', 'api', 'final', 'velocity'
+include 'bukkit', 'bungee', 'shared', 'api', 'final', 'velocity', 'proxy'

--- a/velocity/build.gradle
+++ b/velocity/build.gradle
@@ -9,5 +9,6 @@ dependencies {
     compileOnly 'com.velocitypowered:velocity-api:1.0.0-SNAPSHOT'
     annotationProcessor 'com.velocitypowered:velocity-api:1.0.0-SNAPSHOT'
 
-    implementation project(":shared")
+    implementation project(':shared')
+    implementation project(':proxy')
 }

--- a/velocity/build.gradle
+++ b/velocity/build.gradle
@@ -5,9 +5,17 @@ repositories {
     }
 }
 
+task setVersion(type: Copy) {
+    from 'src/main/resources'
+    into 'build/resources/main'
+    expand(version: project.version)
+    filteringCharset = 'UTF-8'
+}
+
+tasks.jar.dependsOn setVersion
+
 dependencies {
     compileOnly 'com.velocitypowered:velocity-api:3.0.0'
-    annotationProcessor 'com.velocitypowered:velocity-api:3.0.0'
 
     implementation project(':shared')
     implementation project(':proxy')

--- a/velocity/build.gradle
+++ b/velocity/build.gradle
@@ -6,8 +6,8 @@ repositories {
 }
 
 dependencies {
-    compileOnly 'com.velocitypowered:velocity-api:1.0.0-SNAPSHOT'
-    annotationProcessor 'com.velocitypowered:velocity-api:1.0.0-SNAPSHOT'
+    compileOnly 'com.velocitypowered:velocity-api:3.0.0'
+    annotationProcessor 'com.velocitypowered:velocity-api:3.0.0'
 
     implementation project(':shared')
     implementation project(':proxy')

--- a/velocity/build.gradle
+++ b/velocity/build.gradle
@@ -1,0 +1,13 @@
+repositories {
+    maven {
+        name 'velocity'
+        url 'https://repo.velocitypowered.com/snapshots/'
+    }
+}
+
+dependencies {
+    compileOnly 'com.velocitypowered:velocity-api:1.0.0-SNAPSHOT'
+    annotationProcessor 'com.velocitypowered:velocity-api:1.0.0-SNAPSHOT'
+
+    implementation project(":shared")
+}

--- a/velocity/src/main/java/com/lauriethefish/betterportals/velocity/BetterPortals.java
+++ b/velocity/src/main/java/com/lauriethefish/betterportals/velocity/BetterPortals.java
@@ -1,0 +1,14 @@
+package com.lauriethefish.betterportals.velocity;
+
+import com.velocitypowered.api.plugin.Plugin;
+import org.slf4j.Logger;
+
+import javax.inject.Inject;
+
+@Plugin(id = "better-portals", name = "BetterPortals", version = "0.10.0", authors = "lauriethefish@outlook.com")
+public class BetterPortals {
+    @Inject
+    public BetterPortals(Logger logger) {
+        logger.info("BetterPortals loaded!");
+    }
+}

--- a/velocity/src/main/java/com/lauriethefish/betterportals/velocity/BetterPortals.java
+++ b/velocity/src/main/java/com/lauriethefish/betterportals/velocity/BetterPortals.java
@@ -1,14 +1,96 @@
 package com.lauriethefish.betterportals.velocity;
 
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.lauriethefish.betterportals.proxy.net.IClientHandler;
+import com.lauriethefish.betterportals.proxy.net.IPortalServer;
+import com.lauriethefish.betterportals.shared.net.RequestException;
+import com.lauriethefish.betterportals.shared.net.requests.PreviousServerPutRequest;
+import com.velocitypowered.api.event.Subscribe;
+import com.velocitypowered.api.event.player.ServerConnectedEvent;
+import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
+import com.velocitypowered.api.event.proxy.ProxyShutdownEvent;
 import com.velocitypowered.api.plugin.Plugin;
+import com.velocitypowered.api.proxy.ProxyServer;
 import org.slf4j.Logger;
 
 import javax.inject.Inject;
 
 @Plugin(id = "better-portals", name = "BetterPortals", version = "0.10.0", authors = "lauriethefish@outlook.com")
 public class BetterPortals {
+    private final Injector injector;
+    private final Logger logger;
+    private IPortalServer portalServer;
+
     @Inject
-    public BetterPortals(Logger logger) {
-        logger.info("BetterPortals loaded!");
+    public BetterPortals(MainModule mainModule, Logger logger) {
+        this.injector = Guice.createInjector(mainModule);
+        this.logger = logger;
+    }
+
+    @Subscribe
+    public void onProxyInitialization(ProxyInitializeEvent event) {
+        try {
+            injector.getInstance(Config.class).load();
+        } catch (Exception ex) {
+            logger.error("Failed to load config file", ex);
+            return;
+        }
+
+        try {
+            this.portalServer = injector.getInstance(IPortalServer.class);
+            portalServer.startUp();
+        }   catch(RuntimeException ex) {
+            logger.error("Failed to start up portal server", ex);
+        }
+    }
+
+    @Subscribe
+    public void onProxyShutdown(ProxyShutdownEvent event) {
+        if(portalServer != null) {
+            try {
+                portalServer.shutDown();
+            }   catch(RuntimeException ex) {
+                logger.error("Failed to shut down portal server", ex);
+            }
+        }
+    }
+
+    @Subscribe
+    public void onServerSwitch(ServerConnectedEvent event) {
+        if(portalServer == null) { return; }
+
+        if(!event.getPreviousServer().isPresent()) {
+            return; // We only care about changes between two servers for selection copying
+        }
+
+        IClientHandler to = portalServer.getServer(event.getServer().getServerInfo().getName());
+
+        String previousServerName = event.getPreviousServer().get().getServerInfo().getName();
+        IClientHandler from = portalServer.getServer(event.getServer().getServerInfo().getName());
+
+        if(from == null) {
+            logger.debug("From server was unregistered for server switch event, skipping");
+            return;
+        }
+
+        if(to == null) {
+            logger.debug("To server was unregistered for server switch event, skipping");
+            return;
+        }
+
+        logger.debug("Sending previous server put request");
+        PreviousServerPutRequest request = new PreviousServerPutRequest();
+        request.setPlayerId(event.getPlayer().getUniqueId());
+        request.setPreviousServer(previousServerName);
+
+        to.sendRequest(request, (response) -> {
+            try {
+                response.checkForErrors();
+            }   catch(RequestException ex) {
+                logger.warn("Failed to set previous server for player {}", event.getPlayer().getUniqueId());
+                ex.printStackTrace();
+            }
+        });
     }
 }

--- a/velocity/src/main/java/com/lauriethefish/betterportals/velocity/BetterPortals.java
+++ b/velocity/src/main/java/com/lauriethefish/betterportals/velocity/BetterPortals.java
@@ -10,13 +10,10 @@ import com.velocitypowered.api.event.Subscribe;
 import com.velocitypowered.api.event.player.ServerConnectedEvent;
 import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
 import com.velocitypowered.api.event.proxy.ProxyShutdownEvent;
-import com.velocitypowered.api.plugin.Plugin;
-import com.velocitypowered.api.proxy.ProxyServer;
 import org.slf4j.Logger;
 
 import javax.inject.Inject;
 
-@Plugin(id = "better-portals", name = "BetterPortals", version = "0.10.0", authors = "lauriethefish@outlook.com")
 public class BetterPortals {
     private final Injector injector;
     private final Logger logger;

--- a/velocity/src/main/java/com/lauriethefish/betterportals/velocity/Config.java
+++ b/velocity/src/main/java/com/lauriethefish/betterportals/velocity/Config.java
@@ -1,0 +1,105 @@
+package com.lauriethefish.betterportals.velocity;
+
+import com.google.inject.Inject;
+import com.lauriethefish.betterportals.proxy.IProxyConfig;
+import com.lauriethefish.betterportals.shared.logging.Logger;
+import com.moandjiezana.toml.Toml;
+import com.moandjiezana.toml.TomlWriter;
+import lombok.Getter;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.logging.Level;
+
+@Singleton
+public class Config implements IProxyConfig {
+    private final Path dataDirectory;
+    private final Logger logger;
+
+    @Getter private InetSocketAddress bindAddress;
+    @Getter private UUID key;
+
+    @Inject
+    public Config(@Named("dataDirectory") Path dataDirectory, Logger logger) {
+        this.dataDirectory = dataDirectory;
+        this.logger = logger;
+    }
+
+    private Path getConfigFilePath() {
+        File dataFolder = dataDirectory.toFile();
+        dataFolder.mkdir();
+
+        return dataFolder.toPath().resolve("config.toml");
+    }
+
+    private Toml loadFile() throws IOException {
+        Path configFilePath = getConfigFilePath();
+        File configFile = configFilePath.toFile();
+        if (!configFile.exists()) {
+            logger.info("Saving default config . . .");
+            InputStream defaultConfig = getClass().getResourceAsStream("/velocityconfig.toml");
+            if(defaultConfig == null) {
+                throw new IllegalStateException("Could not find default config file!");
+            }
+
+            Files.copy(defaultConfig, configFilePath);
+        }
+
+        return new Toml().read(configFile);
+    }
+
+    private void saveFile(Map<String, Object> config) throws IOException {
+        TomlWriter tomlWriter = new TomlWriter();
+        tomlWriter.write(config, getConfigFilePath().toFile());
+    }
+
+    public void load() throws IOException {
+        Toml configFile = loadFile();
+        boolean wasModified = false;
+
+        Map<String, Object> configMap = configFile.toMap();
+
+        if(!configMap.containsKey("logLevel")) {
+            configMap.put("logLevel", "INFO");
+            configMap.remove("enableDebugLogging");
+            wasModified = true;
+        }
+
+        Level configuredLevel = Level.parse((String) configMap.get("logLevel"));
+        logger.setLevel(configuredLevel);
+
+        String addressStr = configFile.getString("bindAddress");
+        if(addressStr == null) {
+            throw new RuntimeException("Missing bind address");
+        }
+
+        int port = Math.toIntExact(configFile.getLong("serverPort"));
+        if(port == 0) {
+            throw new RuntimeException("Invalid bind port " + port);
+        }
+
+        try {
+            key = UUID.fromString(Objects.requireNonNull((String) configMap.get("key"), "No encryption key found in the config"));
+        }   catch(IllegalArgumentException ex) {
+            logger.info("Generating new random encryption key");
+            key = UUID.randomUUID();
+            configMap.put("key", key.toString());
+            wasModified = true;
+        }
+
+        bindAddress = new InetSocketAddress(addressStr, port);
+
+        if(wasModified) {
+            saveFile(configMap);
+        }
+    }
+}

--- a/velocity/src/main/java/com/lauriethefish/betterportals/velocity/MainModule.java
+++ b/velocity/src/main/java/com/lauriethefish/betterportals/velocity/MainModule.java
@@ -1,0 +1,47 @@
+package com.lauriethefish.betterportals.velocity;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.name.Names;
+import com.lauriethefish.betterportals.proxy.IProxy;
+import com.lauriethefish.betterportals.proxy.IProxyConfig;
+import com.lauriethefish.betterportals.proxy.net.ProxyModule;
+import com.lauriethefish.betterportals.shared.logging.Logger;
+import com.velocitypowered.api.plugin.PluginContainer;
+import com.velocitypowered.api.plugin.annotation.DataDirectory;
+import com.velocitypowered.api.proxy.ProxyServer;
+
+import javax.inject.Inject;
+import java.nio.file.Path;
+import java.util.Optional;
+
+public class MainModule extends AbstractModule {
+    private final ProxyServer proxyServer;
+    private final Path dataDirectory;
+    private final org.slf4j.Logger logger;
+
+    private final String pluginVersion;
+
+    @Inject
+    public MainModule(ProxyServer proxyServer, @DataDirectory Path dataDirectory, PluginContainer pluginContainer, org.slf4j.Logger logger) {
+        this.proxyServer = proxyServer;
+        this.dataDirectory = dataDirectory;
+        this.logger = logger;
+
+        Optional<String> version = pluginContainer.getDescription().getVersion();
+        if(!version.isPresent()) {
+            throw new IllegalStateException("Plugin had no version");
+        }
+        this.pluginVersion = version.get();
+    }
+
+    protected void configure() {
+        install(new ProxyModule());
+
+        bind(IProxyConfig.class).to(Config.class);
+        bind(ProxyServer.class).toInstance(proxyServer);
+        bind(IProxy.class).to(VelocityProxy.class);
+        bind(String.class).annotatedWith(Names.named("pluginVersion")).toInstance(pluginVersion);
+        bind(Path.class).annotatedWith(Names.named("dataDirectory")).toInstance(dataDirectory);
+        bind(Logger.class).toInstance(new VelocityLogger(logger));
+    }
+}

--- a/velocity/src/main/java/com/lauriethefish/betterportals/velocity/VelocityLogger.java
+++ b/velocity/src/main/java/com/lauriethefish/betterportals/velocity/VelocityLogger.java
@@ -1,0 +1,25 @@
+package com.lauriethefish.betterportals.velocity;
+
+import com.lauriethefish.betterportals.shared.logging.Logger;
+
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+public class VelocityLogger extends Logger {
+    private final org.slf4j.Logger logger;
+
+    protected VelocityLogger(org.slf4j.Logger logger) {
+        super(logger.getName(), null);
+        setLevel(Level.INFO);
+
+        this.logger = logger;
+    }
+
+    @Override
+    public void log(LogRecord record) {
+        // Return if the log level is too low
+        if(record.getLevel().intValue() < super.getLevel().intValue()) {return;}
+
+        logger.info(record.getMessage());
+    }
+}

--- a/velocity/src/main/java/com/lauriethefish/betterportals/velocity/VelocityLogger.java
+++ b/velocity/src/main/java/com/lauriethefish/betterportals/velocity/VelocityLogger.java
@@ -20,6 +20,20 @@ public class VelocityLogger extends Logger {
         // Return if the log level is too low
         if(record.getLevel().intValue() < super.getLevel().intValue()) {return;}
 
-        logger.info(record.getMessage());
+        // Approximately convert between log4j and java.util logging levels
+        int recordLevel = record.getLevel().intValue();
+        if(recordLevel >= Level.SEVERE.intValue()) {
+            logger.error("{}", record.getMessage());
+        }   else if(recordLevel >= Level.WARNING.intValue()) {
+            logger.warn("{}", record.getMessage());
+        }   else if(recordLevel >= Level.INFO.intValue()) {
+            logger.info("{}", record.getMessage());
+        }   else if(recordLevel >= Level.FINE.intValue()) {
+            logger.info("[FNE] {}", record.getMessage());
+        }   else if(recordLevel >= Level.FINER.intValue()) {
+            logger.info("[FNR] {}", record.getMessage());
+        }   else if(recordLevel >= Level.FINEST.intValue()) {
+            logger.info("[FST] {}", record.getMessage());
+        }
     }
 }

--- a/velocity/src/main/java/com/lauriethefish/betterportals/velocity/VelocityProxy.java
+++ b/velocity/src/main/java/com/lauriethefish/betterportals/velocity/VelocityProxy.java
@@ -1,0 +1,64 @@
+package com.lauriethefish.betterportals.velocity;
+
+import com.lauriethefish.betterportals.proxy.IProxy;
+import com.velocitypowered.api.proxy.Player;
+import com.velocitypowered.api.proxy.ProxyServer;
+import com.velocitypowered.api.proxy.server.RegisteredServer;
+import lombok.Getter;
+import org.jetbrains.annotations.Nullable;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+import java.net.InetSocketAddress;
+import java.util.Optional;
+import java.util.UUID;
+
+@Singleton
+public class VelocityProxy implements IProxy {
+    private final ProxyServer proxyServer;
+    @Getter private final String pluginVersion;
+
+    @Inject
+    public VelocityProxy(ProxyServer proxyServer, @Named("pluginVersion") String pluginVersion) {
+        this.proxyServer = proxyServer;
+        this.pluginVersion = pluginVersion;
+    }
+
+    @Override
+    public @Nullable String findServer(InetSocketAddress clientAddress) {
+        for(RegisteredServer server : proxyServer.getAllServers()) {
+            InetSocketAddress serverAddress = server.getServerInfo().getAddress();
+            if(serverAddress.equals(clientAddress)) {
+                return server.getServerInfo().getName();
+            }
+        }
+
+        return null;
+    }
+
+    @Override
+    public boolean serverExists(String serverName) {
+        return proxyServer.getServer(serverName).isPresent();
+    }
+
+    @Override
+    public boolean playerExists(UUID uid) {
+        return proxyServer.getPlayer(uid).isPresent();
+    }
+
+    @Override
+    public void changePlayerServer(UUID uid, String destinationServer) {
+        Optional<Player> player = proxyServer.getPlayer(uid);
+        if(!player.isPresent()) {
+            throw new IllegalArgumentException(String.format("No player existed with UUID %s", uid));
+        }
+
+        Optional<RegisteredServer> server = proxyServer.getServer(destinationServer);
+        if(!server.isPresent()) {
+            throw new IllegalArgumentException(String.format("No server existed with the UUID %s", destinationServer));
+        }
+
+        player.get().createConnectionRequest(server.get());
+    }
+}

--- a/velocity/src/main/java/com/lauriethefish/betterportals/velocity/VelocityProxy.java
+++ b/velocity/src/main/java/com/lauriethefish/betterportals/velocity/VelocityProxy.java
@@ -59,6 +59,6 @@ public class VelocityProxy implements IProxy {
             throw new IllegalArgumentException(String.format("No server existed with the UUID %s", destinationServer));
         }
 
-        player.get().createConnectionRequest(server.get());
+        player.get().createConnectionRequest(server.get()).fireAndForget();
     }
 }

--- a/velocity/src/main/resources/velocity-plugin.json
+++ b/velocity/src/main/resources/velocity-plugin.json
@@ -1,0 +1,10 @@
+{
+  "id": "better-portals",
+  "name": "BetterPortals",
+  "version": "${version}",
+  "authors": [
+    "lauriethefish@outlook.com"
+  ],
+  "dependencies": [],
+  "main": "com.lauriethefish.betterportals.velocity.BetterPortals"
+}

--- a/velocity/src/main/resources/velocityconfig.toml
+++ b/velocity/src/main/resources/velocityconfig.toml
@@ -1,0 +1,4 @@
+bindAddress = "0.0.0.0" # Change this to 127.0.0.1 to only allow local connections
+serverPort = 25510 # The port that the server will listen on
+enableDebugLogging = false # Setting this to true will make the plugin print much more detailed info about what is happenning. Useful for finding issues.
+key = "" # Used to authenticate and encrypt connecting servers. This is automatically generated if empty/invalid


### PR DESCRIPTION
This PR adds support for the [velocity](https://velocitypowered.com/) proxy.
The implementation of this involved separating the portal server code into a new `proxy` module, adapting the bungeecord plugin to use this code, then adding a simple velocity module that bootstraps the server.

The velocity plugin is also shaded into the main JAR.