### PR TITLE
WorldGuard compatibility

### DIFF
--- a/bukkit/build.gradle
+++ b/bukkit/build.gradle
@@ -7,6 +7,7 @@ repositories {
     maven { url "https://repo.dmulloy2.net/nexus/repository/public/" }
     maven { url = 'https://hub.spigotmc.org/nexus/content/repositories/snapshots/' }
     maven { url = 'https://oss.sonatype.org/content/repositories/snapshots' }
+    maven { url = "https://maven.enginehub.org/repo/" }
 }
 
 
@@ -19,6 +20,7 @@ dependencies {
     implementation project(':api')
     compileOnly 'com.comphenix.protocol:ProtocolLib:4.8.0-SNAPSHOT'
     compileOnly 'org.spigotmc:spigot-api:1.18.1-R0.1-SNAPSHOT'
+    compileOnly 'com.sk89q.worldguard:worldguard-bukkit:7.0.4'
 }
 
 bukkit {
@@ -30,7 +32,7 @@ bukkit {
     apiVersion = '1.13'
     author = 'lauriethefish@outlook.com'
     depend = ['ProtocolLib']
-    softDepend = ['Multiverse-Core']
+    softDepend = ['Multiverse-Core', 'WorldGuard']
 
     commands {
         betterportals {

--- a/bukkit/src/main/java/com/lauriethefish/betterportals/bukkit/command/TestingCommands.java
+++ b/bukkit/src/main/java/com/lauriethefish/betterportals/bukkit/command/TestingCommands.java
@@ -63,7 +63,7 @@ public class TestingCommands {
     @RequiresPlayer
     public boolean testIsValidSpawnPos(Player player, PortalDirection direction, int sizeX, int sizeY) {
         Vector size = new Vector(sizeX, sizeY, 0.0);
-        player.sendMessage(String.valueOf(spawnChecker.isValidPortalSpawnPosition(player.getLocation().subtract(0.0, 1.0, 0.0), direction, size)));
+        player.sendMessage(String.valueOf(spawnChecker.isValidPortalSpawnPosition(player.getLocation().subtract(0.0, 1.0, 0.0), direction, size, player)));
 
         return true;
     }

--- a/bukkit/src/main/java/com/lauriethefish/betterportals/bukkit/portal/spawning/IPortalSpawner.java
+++ b/bukkit/src/main/java/com/lauriethefish/betterportals/bukkit/portal/spawning/IPortalSpawner.java
@@ -1,6 +1,7 @@
 package com.lauriethefish.betterportals.bukkit.portal.spawning;
 
 import org.bukkit.Location;
+import org.bukkit.entity.Player;
 import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
 
@@ -12,7 +13,8 @@ public interface IPortalSpawner {
      * @param originPosition The position of the portal that was lit
      * @param size The size of the lit portal
      * @param onFinish Called with the resultant position when finished
+     * @param creatingPlayer Player which creates portal
      * @return true once the spawn has started, false if no valid WorldLink was found.
      */
-    boolean findAndSpawnDestination(@NotNull Location originPosition, @NotNull Vector size, Consumer<PortalSpawnPosition> onFinish);
+    boolean findAndSpawnDestination(@NotNull Location originPosition, @NotNull Vector size, Player creatingPlayer, Consumer<PortalSpawnPosition> onFinish);
 }

--- a/bukkit/src/main/java/com/lauriethefish/betterportals/bukkit/portal/spawning/PortalSpawner.java
+++ b/bukkit/src/main/java/com/lauriethefish/betterportals/bukkit/portal/spawning/PortalSpawner.java
@@ -13,6 +13,7 @@ import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.WorldBorder;
 import org.bukkit.block.BlockState;
+import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
@@ -44,7 +45,7 @@ public class PortalSpawner implements IPortalSpawner {
     }
 
     @Override
-    public boolean findAndSpawnDestination(@NotNull Location originPosition, @NotNull Vector originSize, Consumer<PortalSpawnPosition> onFinish) {
+    public boolean findAndSpawnDestination(@NotNull Location originPosition, @NotNull Vector originSize, Player creatingPlayer, Consumer<PortalSpawnPosition> onFinish) {
         World originWorld = originPosition.getWorld();
         assert originWorld != null;
 
@@ -58,7 +59,7 @@ public class PortalSpawner implements IPortalSpawner {
         Location destinationPosition = limitByWorldBorder(rawDestPos);
         logger.fine("Preferred destination position: %s", destinationPosition.toVector());
 
-        PortalSpawningContext context = new PortalSpawningContext(link, destinationPosition, originSize);
+        PortalSpawningContext context = new PortalSpawningContext(link, destinationPosition, originSize, creatingPlayer);
         logger.fine("Searching for existing position");
         startAsyncCheck(context, existingPortalChecker, (existingPosition) -> {
             if(existingPosition != null) {
@@ -72,7 +73,8 @@ public class PortalSpawner implements IPortalSpawner {
                     // Give up and just use the preferred destination position, which is probably in a wall, but it's our only real option
                     if(newSpawnPos == null) {
                         logger.warning("Unable to find destination for a portal. This shouldn't happen really");
-                        newSpawnPos = new PortalSpawnPosition(destinationPosition, originSize, PortalDirection.EAST);
+                        onFinish.accept(null);
+                        return;
                     }
 
                     logger.fine("Creating with new position");

--- a/bukkit/src/main/java/com/lauriethefish/betterportals/bukkit/portal/spawning/PortalSpawningContext.java
+++ b/bukkit/src/main/java/com/lauriethefish/betterportals/bukkit/portal/spawning/PortalSpawningContext.java
@@ -3,6 +3,7 @@ package com.lauriethefish.betterportals.bukkit.portal.spawning;
 import com.lauriethefish.betterportals.bukkit.config.WorldLink;
 import lombok.Getter;
 import org.bukkit.Location;
+import org.bukkit.entity.Player;
 import org.bukkit.util.Vector;
 
 /**
@@ -13,15 +14,18 @@ public class PortalSpawningContext {
     private final WorldLink worldLink;
     private final Location preferredLocation;
     private final Vector size;
+    private final Player creatingPlayer;
 
     /**
      * @param worldLink Contains info about how the two worlds are connected, e.g. min/max spawn height, coordinate rescaling
      * @param preferredLocation The location in the destination world where we want to spawn the portal
      * @param size The size of the origin portal window.
+     * @param creatingPlayer Player which creates portal
      */
-    public PortalSpawningContext(WorldLink worldLink, Location preferredLocation, Vector size) {
+    public PortalSpawningContext(WorldLink worldLink, Location preferredLocation, Vector size, Player creatingPlayer) {
         this.worldLink = worldLink;
         this.preferredLocation = preferredLocation;
         this.size = size;
+        this.creatingPlayer = creatingPlayer;
     }
 }

--- a/bukkit/src/main/resources/config.yml
+++ b/bukkit/src/main/resources/config.yml
@@ -177,6 +177,8 @@ chatMessages:
                 BetterPortals overrides the behaviour of plugins like MultiverseNetherPortals, so these should be uninstalled unless you're in a world that is manually excluded in the config.
                 This message can be disabled in the BetterPortals config"
 
+  noSpaceLink: "This portal couldn't find space to rest on the other world"
+
   # Printed if the player lights a portal over the size limit
   # To disable, just remove all the text inside the quotes.
   portalTooBig: "This portal is too big. The current size limit is {size}. You can increase it in the BetterPortals config.


### PR DESCRIPTION
This PR adds compatibility with WorldGuard plugin.

When BetterPortals tries to create new portal using NewPortalChecker it checks for WG plugin and if it is enabled checks if player can build in desired location. If somehow player would not be provided default logic of WG is used 